### PR TITLE
Replaced <h4> with <h5> in table headers

### DIFF
--- a/templates/ebi_templates.js
+++ b/templates/ebi_templates.js
@@ -93,7 +93,7 @@ CKEDITOR.addTemplates("ebi_templates",
       html:`<table class="hover">
               <thead>
               <tr>
-                <th colspan="3"><h4>Monday 3 September 2018</h4></th>
+                <th colspan="3"><h5>Monday 3 September 2018</h5></th>
               </tr>
               </thead>
               <tbody>
@@ -155,7 +155,7 @@ CKEDITOR.addTemplates("ebi_templates",
       html:`<table class="hover">
               <thead>
               <tr>
-                <th colspan="3" class="secondary-background white-color"><h4>Day 1 – Monday 3 September 2018</h4></th>
+                <th colspan="3" class="secondary-background white-color"><h5>Day 1 – Monday 3 September 2018</h5></th>
               </tr>
               </thead>
               <tbody>
@@ -212,7 +212,7 @@ CKEDITOR.addTemplates("ebi_templates",
         <table class="hover">
           <thead>
             <tr>
-              <th colspan="3" class="secondary-background white-color"><h4>Day 2 – Monday 4 September 2018</h4></th>
+              <th colspan="3" class="secondary-background white-color"><h5>Day 2 – Monday 4 September 2018</h5></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
The table headers `<th>` in this programme template is having a white background and the content `<h4>` in the table header `<th>` also shows up in white font color which makes them invisible. Replaced `<h4>` with `<h5>` in table headers in order to solve issue of white background.